### PR TITLE
Refactor pathfinding and chapter runtime

### DIFF
--- a/Content/Game/Levels/Map_Persistent.umap
+++ b/Content/Game/Levels/Map_Persistent.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:67910ac654f6be5aecf85191b13e4a9391ff92ce2a8c37f142c5aeb4d2004c77
-size 49531
+oid sha256:cd817c7a841c5928c70a3a326160ab69558b5a764bbc34a2bd6e23b019263939
+size 49556

--- a/Source/GT5_Projet/Private/Core/PawnIsometric.cpp
+++ b/Source/GT5_Projet/Private/Core/PawnIsometric.cpp
@@ -244,6 +244,21 @@ void APawnIsometric::SetCursorHidden(bool bCursorHidden)
 	}
 }
 
+void APawnIsometric::SetMapCharacter(AVNMapCharacter* InPlayerCharacter)
+{
+	PlayerCharacter = InPlayerCharacter;
+}
+
+void APawnIsometric::SetMapBounds(AVNMapBounds* InMapBounds)
+{
+	MapBounds = InMapBounds;
+}
+
+void APawnIsometric::SetCharacterHeightLevel(float InCharacterHeightLevel)
+{
+	CharacterHeightLevel = InCharacterHeightLevel;
+}
+
 
 void APawnIsometric::Input_PanCameraX(float w)
 {

--- a/Source/GT5_Projet/Private/Core/VNChapterManager.cpp
+++ b/Source/GT5_Projet/Private/Core/VNChapterManager.cpp
@@ -6,6 +6,8 @@
 #include "GameFramework/PlayerStart.h"
 #include "Engine/GameInstance.h"
 
+#include "Core/PawnIsometric.h"
+#include "Map/VNMapCharacter.h"
 #include "Map/VNMapBounds.h"
 #include "Libraries/UtilsLibrary.h"
 #include "Libraries/VNTileMapLibrary.h"
@@ -22,7 +24,67 @@ void AVNChapterManager::BeginPlay()
 {
 	Super::BeginPlay();
 
-	// Spawn camera pawn and map character (distinct actors!)
+	SpawnChapterActors();
+	PlaceCharacterAtPlayerStart();
+}
+
+void AVNChapterManager::EndPlay(EEndPlayReason::Type Reason)
+{
+	if (MapCharacter) {
+		MapCharacter->Destroy();
+	}
+
+	if (PawnCamera) {
+		PawnCamera->Destroy();
+	}
+
+	Super::EndPlay(Reason);
+}
+
+void AVNChapterManager::Enable_Implementation()
+{
+	APlayerController* pc = UGameplayStatics::GetPlayerController(this, 0);
+	UVNChapterSubsystem* subsys = UGameplayStatics::GetGameInstance(this)->GetSubsystem<UVNChapterSubsystem>();
+	ULevelStreaming* LevelStream = UGameplayStatics::GetStreamingLevel(this, subsys->CurrentChapterLevel.GetLongPackageFName());
+
+	if (PawnCamera && pc) {
+		pc->Possess(PawnCamera);
+	}
+	ConfigureCameraBounds(LevelStream);
+
+	if (MapCharacter) {
+		MapCharacter->Enable();
+	}
+
+	ConfigureMapInput(pc);
+}
+
+void AVNChapterManager::Disable_Implementation()
+{
+	if (PawnCamera) {
+		PawnCamera->SetCursorActive(false);
+	}
+
+	if (MapCharacter) {
+		MapCharacter->Disable();
+	}
+}
+
+void AVNChapterManager::TravelOnHeightSwitcher_Implementation(AActor* SwitcherA, AActor* SwitcherB)
+{
+	AVNMapCharacter* ch = GetMapCharacter();
+
+	// Teleport character to destination switcher (on the tile in front of it).
+	const FVector Loc = ch->GetActorLocation() - SwitcherA->GetActorLocation() + SwitcherB->GetActorLocation() + (SwitcherB->GetActorForwardVector() * -100.0);
+	ch->SetActorLocation(Loc);
+
+	// Set plane height.
+	GetPawn()->SetCharacterHeightLevel(SwitcherB->GetActorLocation().Z);
+	ch->HeightLevel = SwitcherB->GetActorLocation().Z;
+}
+
+void AVNChapterManager::SpawnChapterActors()
+{
 	if (PawnCameraClass != NULL) {
 		PawnCamera = GetWorld()->SpawnActor<APawnIsometric>(PawnCameraClass);
 	}
@@ -40,9 +102,12 @@ void AVNChapterManager::BeginPlay()
 	}
 
 	if (PawnCamera) {
-		PawnCamera->PlayerCharacter = MapCharacter;
+		PawnCamera->SetMapCharacter(MapCharacter);
 	}
+}
 
+void AVNChapterManager::PlaceCharacterAtPlayerStart()
+{
 	// Place map character at spawn location.
 	// TODO : Hardcoded character height offset (60.0).
 	if (MapCharacter) {
@@ -72,70 +137,24 @@ void AVNChapterManager::BeginPlay()
 	}
 }
 
-void AVNChapterManager::EndPlay(EEndPlayReason::Type Reason)
+void AVNChapterManager::ConfigureCameraBounds(ULevelStreaming* LevelStream)
 {
-	if (MapCharacter) {
-		MapCharacter->Destroy();
-	}
-
 	if (PawnCamera) {
-		PawnCamera->Destroy();
-	}
-
-	Super::EndPlay(Reason);
-}
-
-void AVNChapterManager::Enable_Implementation()
-{
-	APlayerController* pc = UGameplayStatics::GetPlayerController(this, 0);
-	UVNChapterSubsystem* subsys = UGameplayStatics::GetGameInstance(this)->GetSubsystem<UVNChapterSubsystem>();
-	ULevelStreaming* LevelStream = UGameplayStatics::GetStreamingLevel(this, subsys->CurrentChapterLevel.GetLongPackageFName());
-
-	// Possess pawn.
-	if (PawnCamera) {
-		pc->Possess(PawnCamera);
-
-		// Get map bounds actor.
 		TArray<AVNMapBounds*> bounds; UUtilsLibrary::GetActorsOfClassInStreamedLevel<AVNMapBounds>(bounds, LevelStream, this);
 
-		PawnCamera->MapBounds = bounds.IsEmpty() ? 0 : bounds[0];
+		PawnCamera->SetMapBounds(bounds.IsEmpty() ? 0 : bounds[0]);
 		PawnCamera->SetCursorActive(true);
 	}
+}
 
-	// Show map character.
-	if (MapCharacter) {
-		MapCharacter->Enable();
+void AVNChapterManager::ConfigureMapInput(APlayerController* PlayerController) const
+{
+	if (PlayerController) {
+		PlayerController->bEnableClickEvents = true;
 	}
-
-	// Configure mouse input.
-	pc->bEnableClickEvents = true;
 	if (UGameInstance* GameInstance = UGameplayStatics::GetGameInstance(this)) {
 		if (UCursorSubsystem* CursorSubsys = GameInstance->GetSubsystem<UCursorSubsystem>()) {
 			CursorSubsys->SetMode(ECursorMode::Free);
 		}
 	}
-}
-
-void AVNChapterManager::Disable_Implementation()
-{
-	if (PawnCamera) {
-		PawnCamera->SetCursorActive(false);
-	}
-
-	if (MapCharacter) {
-		MapCharacter->Disable();
-	}
-}
-
-void AVNChapterManager::TravelOnHeightSwitcher_Implementation(AActor* SwitcherA, AActor* SwitcherB)
-{
-	AVNMapCharacter* ch = GetMapCharacter();
-
-	// Teleport character to destination switcher (on the tile in front of it).
-	const FVector Loc = ch->GetActorLocation() - SwitcherA->GetActorLocation() + SwitcherB->GetActorLocation() + (SwitcherB->GetActorForwardVector() * -100.0);
-	ch->SetActorLocation(Loc);
-
-	// Set plane height.
-	GetPawn()->CharacterHeightLevel = SwitcherB->GetActorLocation().Z;
-	ch->HeightLevel = SwitcherB->GetActorLocation().Z;
 }

--- a/Source/GT5_Projet/Private/Libraries/GridPathfinding.cpp
+++ b/Source/GT5_Projet/Private/Libraries/GridPathfinding.cpp
@@ -1,0 +1,116 @@
+#include "Libraries/GridPathfinding.h"
+
+bool FGridPathfinding::FindPath(
+	const FIntPoint& StartTile,
+	const FIntPoint& EndTile,
+	TArray<FIntPoint>& OutPath,
+	const FIsWalkable& IsWalkable,
+	const FIsTerminal& IsTerminal,
+	int32 MaxSearchDistance)
+{
+	OutPath.Empty();
+
+	if (StartTile == EndTile)
+	{
+		OutPath.Add(StartTile);
+		return true;
+	}
+
+	TArray<FNode> Nodes;
+	TArray<int32> OpenSet;
+	TSet<FIntPoint> ClosedSet;
+	TMap<FIntPoint, int32> NodeIndexByPosition;
+
+	const int32 StartIndex = Nodes.Add({ StartTile, 0.0F, CalculateManhattanDistance(StartTile, EndTile), INDEX_NONE });
+	NodeIndexByPosition.Add(StartTile, StartIndex);
+	OpenSet.Add(StartIndex);
+
+	int32 SearchCount = 0;
+	int32 EndIndex = INDEX_NONE;
+
+	while (OpenSet.Num() > 0 && SearchCount < MaxSearchDistance && EndIndex == INDEX_NONE)
+	{
+		SearchCount++;
+
+		int32 LowestOpenSetIndex = 0;
+		for (int32 Index = 1; Index < OpenSet.Num(); Index++)
+		{
+			const FNode& Candidate = Nodes[OpenSet[Index]];
+			const FNode& CurrentLowest = Nodes[OpenSet[LowestOpenSetIndex]];
+			if (Candidate.GetFCost() < CurrentLowest.GetFCost() ||
+				(Candidate.GetFCost() == CurrentLowest.GetFCost() && Candidate.HCost < CurrentLowest.HCost))
+			{
+				LowestOpenSetIndex = Index;
+			}
+		}
+
+		const int32 CurrentIndex = OpenSet[LowestOpenSetIndex];
+		OpenSet.RemoveAt(LowestOpenSetIndex);
+		const FIntPoint CurrentPosition = Nodes[CurrentIndex].Position;
+		const float CurrentGCost = Nodes[CurrentIndex].GCost;
+		ClosedSet.Add(CurrentPosition);
+
+		if (CurrentPosition == EndTile || (IsTerminal.IsBound() && IsTerminal.Execute(CurrentPosition)))
+		{
+			EndIndex = CurrentIndex;
+			break;
+		}
+
+		TArray<FIntPoint, TInlineAllocator<4>> Neighbors;
+		GetNeighbors(Neighbors, CurrentPosition);
+		for (const FIntPoint& NeighborPos : Neighbors)
+		{
+			if (ClosedSet.Contains(NeighborPos) || !IsWalkable.Execute(NeighborPos))
+			{
+				continue;
+			}
+
+			const float NewGCost = CurrentGCost + 1.0F;
+			if (int32* ExistingIndex = NodeIndexByPosition.Find(NeighborPos))
+			{
+				FNode& ExistingNode = Nodes[*ExistingIndex];
+				if (NewGCost < ExistingNode.GCost)
+				{
+					ExistingNode.GCost = NewGCost;
+					ExistingNode.ParentIndex = CurrentIndex;
+				}
+			}
+			else
+			{
+				const int32 NeighborIndex = Nodes.Add({
+					NeighborPos,
+					NewGCost,
+					CalculateManhattanDistance(NeighborPos, EndTile),
+					CurrentIndex
+				});
+				NodeIndexByPosition.Add(NeighborPos, NeighborIndex);
+				OpenSet.Add(NeighborIndex);
+			}
+		}
+	}
+
+	if (EndIndex == INDEX_NONE)
+	{
+		return false;
+	}
+
+	for (int32 CurrentIndex = EndIndex; CurrentIndex != INDEX_NONE; CurrentIndex = Nodes[CurrentIndex].ParentIndex)
+	{
+		OutPath.Insert(Nodes[CurrentIndex].Position, 0);
+	}
+
+	return true;
+}
+
+float FGridPathfinding::CalculateManhattanDistance(const FIntPoint& A, const FIntPoint& B)
+{
+	return FMath::Abs(A.X - B.X) + FMath::Abs(A.Y - B.Y);
+}
+
+void FGridPathfinding::GetNeighbors(TArray<FIntPoint, TInlineAllocator<4>>& OutNeighbors, const FIntPoint& Position)
+{
+	OutNeighbors.Add(FIntPoint(Position.X + 1, Position.Y));
+	OutNeighbors.Add(FIntPoint(Position.X - 1, Position.Y));
+	OutNeighbors.Add(FIntPoint(Position.X, Position.Y + 1));
+	OutNeighbors.Add(FIntPoint(Position.X, Position.Y - 1));
+}

--- a/Source/GT5_Projet/Private/Libraries/PathfindingLibrary.cpp
+++ b/Source/GT5_Projet/Private/Libraries/PathfindingLibrary.cpp
@@ -1,8 +1,10 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
 #include "Libraries/PathfindingLibrary.h"
+#include "Libraries/GridPathfinding.h"
 #include "Libraries/VNTileMapLibrary.h"
 
+#include "Core/PawnIsometric.h"
 #include "Subsystems/VNChapterSubsystem.h"
 
 #include "Subsystems/MapSubsystem.h"
@@ -16,131 +18,24 @@
 
 bool UPathfindingLibrary::FindPath(const FIntPoint& StartTile, const FIntPoint& EndTile, TArray<FIntPoint>& OutPath, const UObject* WorldContext, int32 MaxSearchDistance)
 {
-	OutPath.Empty();
-
-	if (StartTile == EndTile)
+	FGridPathfinding::FIsWalkable IsWalkable;
+	IsWalkable.BindLambda([WorldContext](const FIntPoint& TilePosition)
 	{
-		OutPath.Add(StartTile);
-		return true;
-	}
+		FHitResult HitResult;
+		const bool bHit = FindTileAt(HitResult, TilePosition, WorldContext);
+		DebugLogTile(HitResult, TilePosition);
 
-	TMap<FIntPoint, FAStarNode*> AllNodes;
-	TArray<FAStarNode*> OpenSet;
-	TSet<FIntPoint> ClosedSet;
+		AActor* HitActor = HitResult.GetActor();
+		return bHit && HitActor && (IsTileFloor(HitActor) || IsTileEvent(HitActor));
+	});
 
-	FAStarNode* StartNode = new FAStarNode(StartTile, 0.f, CalculateManhattanDistance(StartTile, EndTile), nullptr);
-	AllNodes.Add(StartTile, StartNode);
-	OpenSet.Add(StartNode);
-
-	int32 SearchCount = 0;
-	bool bPathFound = false;
-	FAStarNode* EndNode = nullptr;
-
-	while (OpenSet.Num() > 0 && SearchCount < MaxSearchDistance && !bPathFound)
+	FGridPathfinding::FIsTerminal IsTerminal;
+	IsTerminal.BindLambda([WorldContext](const FIntPoint& TilePosition)
 	{
-		SearchCount++;
+		return GetTileEvent(TilePosition, WorldContext) != nullptr;
+	});
 
-		int32 LowestFCostIndex = 0;
-		for (int32 i = 1; i < OpenSet.Num(); i++)
-		{
-			if (OpenSet[i]->FCost < OpenSet[LowestFCostIndex]->FCost ||
-				(OpenSet[i]->FCost == OpenSet[LowestFCostIndex]->FCost && OpenSet[i]->HCost < OpenSet[LowestFCostIndex]->HCost))
-			{
-				LowestFCostIndex = i;
-			}
-		}
-
-		FAStarNode* CurrentNode = OpenSet[LowestFCostIndex];
-		OpenSet.RemoveAt(LowestFCostIndex);
-		ClosedSet.Add(CurrentNode->Position);
-
-		if (CurrentNode->Position == EndTile)
-		{
-			bPathFound = true;
-			EndNode = CurrentNode;
-			break;
-		}
-
-		// Stop on first met event.
-		if (GetTileEvent(CurrentNode->Position, WorldContext) != nullptr)
-		{
-			bPathFound = true;
-			EndNode = CurrentNode;
-			break;
-		}
-
-		TInlineComponentArray<FIntPoint, 4> Neighbors;
-		GetNeighbors(Neighbors, CurrentNode->Position);
-		for (const FIntPoint& NeighborPos : Neighbors)
-		{
-			// Skip if already evaluated
-			if (ClosedSet.Contains(NeighborPos))
-			{
-				continue;
-			}
-
-			FHitResult HitResult;
-			bool bHit = FindTileAt(HitResult, NeighborPos, WorldContext);
-			DebugLogTile(HitResult, NeighborPos);
-
-			if (!bHit || HitResult.GetActor() == nullptr)
-			{
-				continue;
-			}
-
-			// Check if the tile is walkable
-			if (!IsTileFloor(HitResult.GetActor()) && !IsTileEvent(HitResult.GetActor()))
-			{
-				continue;
-			}
-
-			// Calculate new G cost (1.0 for orthogonal movement)
-			float NewGCost = CurrentNode->GCost + 1.0f;
-
-			// Check if neighbor is already in open set
-			FAStarNode** ExistingNodePtr = AllNodes.Find(NeighborPos);
-			FAStarNode* NeighborNode = nullptr;
-
-			if (ExistingNodePtr != nullptr)
-			{
-				NeighborNode = *ExistingNodePtr;
-				// If we found a better path, update it
-				if (NewGCost < NeighborNode->GCost)
-				{
-					NeighborNode->GCost = NewGCost;
-					NeighborNode->FCost = NeighborNode->GCost + NeighborNode->HCost;
-					NeighborNode->Parent = CurrentNode;
-				}
-			}
-			else
-			{
-				// Create new node
-				float HCost = CalculateManhattanDistance(NeighborPos, EndTile);
-				NeighborNode = new FAStarNode(NeighborPos, NewGCost, HCost, CurrentNode);
-				AllNodes.Add(NeighborPos, NeighborNode);
-				OpenSet.Add(NeighborNode);
-			}
-		}
-	}
-
-	// Reconstruct path if found
-	if (bPathFound && EndNode != nullptr)
-	{
-		FAStarNode* CurrentNode = EndNode;
-		while (CurrentNode != nullptr)
-		{
-			OutPath.Insert(CurrentNode->Position, 0);
-			CurrentNode = CurrentNode->Parent;
-		}
-	}
-
-	// Cleanup allocated nodes
-	for (auto& Pair : AllNodes)
-	{
-		delete Pair.Value;
-	}
-
-	return bPathFound;
+	return FGridPathfinding::FindPath(StartTile, EndTile, OutPath, IsWalkable, IsTerminal, MaxSearchDistance);
 }
 
 bool UPathfindingLibrary::IsTileWalkable(const FIntPoint& TilePosition, const UObject* WorldContext)
@@ -171,11 +66,6 @@ AVNMapEvent* UPathfindingLibrary::GetTileEvent(const FIntPoint& TilePosition, co
 
 	UMapSubsystem* Subsys = World->GetSubsystem<UMapSubsystem>();
 	return Subsys ? Subsys->GetMapEventAt(TilePosition) : nullptr;
-}
-
-float UPathfindingLibrary::CalculateManhattanDistance(const FIntPoint& A, const FIntPoint& B)
-{
-	return FMath::Abs(A.X - B.X) + FMath::Abs(A.Y - B.Y);
 }
 
 bool UPathfindingLibrary::FindTileAt(FHitResult& OutResult, const FIntPoint& Pos, const UObject* WorldContext)
@@ -224,14 +114,6 @@ bool UPathfindingLibrary::IsTileFloor(AActor* HitActor)
 bool UPathfindingLibrary::IsTileEvent(AActor* HitActor)
 {
 	return HitActor->ActorHasTag(UVNTileMapLibrary::EventTag);
-}
-
-void UPathfindingLibrary::GetNeighbors(TInlineComponentArray<FIntPoint, 4>& outNeighbors, const FIntPoint& Position)
-{
-	outNeighbors.Add(FIntPoint(Position.X + 1, Position.Y));     // Right
-	outNeighbors.Add(FIntPoint(Position.X - 1, Position.Y));     // Left
-	outNeighbors.Add(FIntPoint(Position.X, Position.Y + 1));     // Up
-	outNeighbors.Add(FIntPoint(Position.X, Position.Y - 1));     // Down
 }
 
 void UPathfindingLibrary::DebugLogTile(const FHitResult& HitResult, const FIntPoint& TilePosition)

--- a/Source/GT5_Projet/Private/Subsystems/VNChapterSubsystem.cpp
+++ b/Source/GT5_Projet/Private/Subsystems/VNChapterSubsystem.cpp
@@ -4,8 +4,12 @@
 
 #include "Kismet/GameplayStatics.h"
 
+#include "Core/PawnIsometric.h"
+#include "Core/VNChapterManager.h"
 #include "Core/VNGameInstance.h"
 #include "Libraries/VNTileMapLibrary.h"
+#include "Map/VNMapCharacter.h"
+#include "Minigames/BaseMinigameManager.h"
 #include "Subsystems/SceneTransitionSubsystem.h"
 
 
@@ -55,13 +59,18 @@ void UVNChapterSubsystem::CloseChapter()
 
 bool UVNChapterSubsystem::InitializeMinigame(TSubclassOf<ABaseMinigameManager> ManagerClass, TSubclassOf<APawn> PawnClass, const UObject* WorldContextObject)
 {
-	ChapterManager->Disable();
+	if (ChapterManager) {
+		ChapterManager->Disable();
+	}
 
-	MinigameManager = GetWorld()->SpawnActor<ABaseMinigameManager>(ManagerClass);
-	MinigamePawn = GetWorld()->SpawnActor<APawn>(PawnClass);
+	if (!SpawnMinigameRuntime(ManagerClass, PawnClass)) {
+		return false;
+	}
 
 	APlayerController* pc = UGameplayStatics::GetPlayerController(WorldContextObject, 0);
-	pc->Possess(MinigamePawn);
+	if (pc && MinigamePawn) {
+		pc->Possess(MinigamePawn);
+	}
 
 	MinigameManager->Initialize();
 
@@ -70,17 +79,12 @@ bool UVNChapterSubsystem::InitializeMinigame(TSubclassOf<ABaseMinigameManager> M
 
 void UVNChapterSubsystem::ExitMinigame(const UObject* WorldContextObject)
 {
-	MinigameManager->Destroy();
-	MinigameManager = 0;
+	DestroyMinigameRuntime();
 
-	if (MinigamePawn) {
-		MinigamePawn->Destroy();
-		MinigamePawn = 0;
+	if (ChapterManager) {
+		ChapterManager->Enable();
 	}
-
-	ChapterManager->Enable();
 }
-
 
 void UVNChapterSubsystem::ModifyConnection(int32 Delta)
 {
@@ -101,6 +105,33 @@ void UVNChapterSubsystem::TriggerMinigame(const FMinigameData& MinigameData, FGu
 	}
 }
 
+void UVNChapterSubsystem::DestroyMinigameRuntime()
+{
+	if (MinigameManager) {
+		MinigameManager->Destroy();
+		MinigameManager = 0;
+	}
+
+	if (MinigamePawn) {
+		MinigamePawn->Destroy();
+		MinigamePawn = 0;
+	}
+}
+
+bool UVNChapterSubsystem::SpawnMinigameRuntime(TSubclassOf<ABaseMinigameManager> ManagerClass, TSubclassOf<APawn> PawnClass)
+{
+	MinigameManager = GetWorld()->SpawnActor<ABaseMinigameManager>(ManagerClass);
+	MinigamePawn = GetWorld()->SpawnActor<APawn>(PawnClass);
+
+	if (!MinigameManager || !MinigamePawn) {
+		UE_LOG(LogTemp, Error, TEXT("Failed to spawn minigame runtime actors."));
+		DestroyMinigameRuntime();
+		return false;
+	}
+
+	return true;
+}
+
 void UVNChapterSubsystem::NotifyChapterComplete()
 {
 	CurrentChapterName = NAME_None;
@@ -117,6 +148,16 @@ void UVNChapterSubsystem::GetConnectionData(
 	OutMin = ConnectionMinValue;
 	OutMax = ConnectionMaxValue;
 	OutValue = Connection;
+}
+
+AVNMapCharacter* UVNChapterSubsystem::GetMapCharacter() const
+{
+	return ChapterManager ? ChapterManager->GetMapCharacter() : 0;
+}
+
+APawnIsometric* UVNChapterSubsystem::GetPawn() const
+{
+	return ChapterManager ? ChapterManager->GetPawn() : 0;
 }
 
 

--- a/Source/GT5_Projet/Private/Tests/ChapterSubsystem.spec.cpp
+++ b/Source/GT5_Projet/Private/Tests/ChapterSubsystem.spec.cpp
@@ -1,0 +1,87 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Subsystems/VNChapterSubsystem.h"
+
+#include "Misc/AutomationTest.h"
+
+namespace
+{
+	UVNChapterSubsystem* CreateChapterSubsystem()
+	{
+		return NewObject<UVNChapterSubsystem>();
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FChapterSubsystemConnectionClampTest,
+	"GT5.Chapter.VNChapterSubsystem.Connection.ClampsAndReportsData",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FChapterSubsystemConnectionClampTest::RunTest(const FString& Parameters)
+{
+	UVNChapterSubsystem* ChapterSubsystem = CreateChapterSubsystem();
+	TestNotNull(TEXT("Chapter subsystem should be created"), ChapterSubsystem);
+
+	ChapterSubsystem->ModifyConnection(150);
+	TestEqual(TEXT("Connection should clamp to max"), ChapterSubsystem->GetConnection(), UVNChapterSubsystem::ConnectionMaxValue);
+
+	ChapterSubsystem->ModifyConnection(-300);
+	TestEqual(TEXT("Connection should clamp to min"), ChapterSubsystem->GetConnection(), UVNChapterSubsystem::ConnectionMinValue);
+
+	int32 OutMin = 0;
+	int32 OutMax = 0;
+	int32 OutValue = 0;
+	ChapterSubsystem->GetConnectionData(OutMin, OutMax, OutValue);
+	TestEqual(TEXT("Connection data should expose min"), OutMin, UVNChapterSubsystem::ConnectionMinValue);
+	TestEqual(TEXT("Connection data should expose max"), OutMax, UVNChapterSubsystem::ConnectionMaxValue);
+	TestEqual(TEXT("Connection data should expose current value"), OutValue, UVNChapterSubsystem::ConnectionMinValue);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FChapterSubsystemStateResetTest,
+	"GT5.Chapter.VNChapterSubsystem.State.NotifyChapterCompleteResetsCurrentChapter",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FChapterSubsystemStateResetTest::RunTest(const FString& Parameters)
+{
+	UVNChapterSubsystem* ChapterSubsystem = CreateChapterSubsystem();
+	TestNotNull(TEXT("Chapter subsystem should be created"), ChapterSubsystem);
+
+	ChapterSubsystem->CurrentChapterName = FName(TEXT("Chapter_01"));
+	ChapterSubsystem->CurrentChapterLevel = TSoftObjectPtr<UWorld>(FSoftObjectPath(TEXT("/Game/Test/Chapter_01.Chapter_01")));
+
+	ChapterSubsystem->NotifyChapterComplete();
+
+	TestTrue(TEXT("Current chapter name should reset"), ChapterSubsystem->CurrentChapterName.IsNone());
+	TestTrue(TEXT("Current chapter level should reset"), ChapterSubsystem->CurrentChapterLevel.IsNull());
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FChapterSubsystemTriggerMinigameTest,
+	"GT5.Chapter.VNChapterSubsystem.Minigame.StoresScheduledDataWithoutManager",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FChapterSubsystemTriggerMinigameTest::RunTest(const FString& Parameters)
+{
+	UVNChapterSubsystem* ChapterSubsystem = CreateChapterSubsystem();
+	TestNotNull(TEXT("Chapter subsystem should be created"), ChapterSubsystem);
+
+	FMinigameData MinigameData;
+	MinigameData.Name = FName(TEXT("KnifeHit"));
+	MinigameData.Description = TEXT("Throw matches at the target");
+
+	const FGuid EventGuid = FGuid::NewGuid();
+	ChapterSubsystem->TriggerMinigame(MinigameData, EventGuid);
+
+	TestEqual(TEXT("Scheduled minigame name should be stored"), ChapterSubsystem->ScheduledMinigame.Name, MinigameData.Name);
+	TestEqual(TEXT("Scheduled minigame description should be stored"), ChapterSubsystem->ScheduledMinigame.Description, MinigameData.Description);
+	TestEqual(TEXT("Last minigame guid should be stored"), ChapterSubsystem->LastMinigameGuid, EventGuid);
+
+	return true;
+}
+
+#endif

--- a/Source/GT5_Projet/Private/Tests/GridPathfinding.spec.cpp
+++ b/Source/GT5_Projet/Private/Tests/GridPathfinding.spec.cpp
@@ -1,0 +1,97 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Libraries/GridPathfinding.h"
+
+#include "Misc/AutomationTest.h"
+
+namespace
+{
+	FGridPathfinding::FIsWalkable WalkableExcept(const TSet<FIntPoint>& BlockedTiles)
+	{
+		FGridPathfinding::FIsWalkable IsWalkable;
+		IsWalkable.BindLambda([BlockedTiles](const FIntPoint& TilePosition)
+		{
+			return !BlockedTiles.Contains(TilePosition);
+		});
+		return IsWalkable;
+	}
+
+	FGridPathfinding::FIsTerminal TerminalAt(const FIntPoint& TerminalTile)
+	{
+		FGridPathfinding::FIsTerminal IsTerminal;
+		IsTerminal.BindLambda([TerminalTile](const FIntPoint& TilePosition)
+		{
+			return TilePosition == TerminalTile;
+		});
+		return IsTerminal;
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGridPathfindingStartEqualsEndTest,
+	"GT5.Pathfinding.GridPathfinding.StartEqualsEnd.ReturnsSingleTile",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGridPathfindingStartEqualsEndTest::RunTest(const FString& Parameters)
+{
+	TArray<FIntPoint> Path;
+	const bool bFoundPath = FGridPathfinding::FindPath(
+		FIntPoint(2, 3),
+		FIntPoint(2, 3),
+		Path,
+		WalkableExcept({}),
+		FGridPathfinding::FIsTerminal());
+
+	TestTrue(TEXT("Start equals end should find a path"), bFoundPath);
+	TestEqual(TEXT("Path should contain exactly the start tile"), Path, TArray<FIntPoint>({ FIntPoint(2, 3) }));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGridPathfindingObstacleTest,
+	"GT5.Pathfinding.GridPathfinding.Obstacles.FindsAlternateRoute",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGridPathfindingObstacleTest::RunTest(const FString& Parameters)
+{
+	TArray<FIntPoint> Path;
+	const bool bFoundPath = FGridPathfinding::FindPath(
+		FIntPoint(0, 0),
+		FIntPoint(2, 0),
+		Path,
+		WalkableExcept({ FIntPoint(1, 0) }),
+		FGridPathfinding::FIsTerminal(),
+		32);
+
+	TestTrue(TEXT("Path should route around the blocked tile"), bFoundPath);
+	TestEqual(TEXT("Path should start at requested tile"), Path[0], FIntPoint(0, 0));
+	TestEqual(TEXT("Path should end at requested tile"), Path.Last(), FIntPoint(2, 0));
+	TestFalse(TEXT("Path should not include blocked tile"), Path.Contains(FIntPoint(1, 0)));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FGridPathfindingTerminalTest,
+	"GT5.Pathfinding.GridPathfinding.Terminal.StopsBeforeEndTile",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FGridPathfindingTerminalTest::RunTest(const FString& Parameters)
+{
+	TArray<FIntPoint> Path;
+	const bool bFoundPath = FGridPathfinding::FindPath(
+		FIntPoint(0, 0),
+		FIntPoint(4, 0),
+		Path,
+		WalkableExcept({}),
+		TerminalAt(FIntPoint(2, 0)),
+		32);
+
+	TestTrue(TEXT("Terminal tile should produce a path"), bFoundPath);
+	TestEqual(TEXT("Path should stop at the terminal tile"), Path.Last(), FIntPoint(2, 0));
+
+	return true;
+}
+
+#endif

--- a/Source/GT5_Projet/Private/Tests/MapSubsystem.spec.cpp
+++ b/Source/GT5_Projet/Private/Tests/MapSubsystem.spec.cpp
@@ -1,0 +1,110 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Subsystems/MapSubsystem.h"
+
+#include "Engine/World.h"
+#include "Map/TileField.h"
+#include "Map/VNMapEvent.h"
+#include "Misc/AutomationTest.h"
+
+namespace
+{
+	ATileField* CreateTileField(UWorld* World, const FVector& Location, int32 SizeX, int32 SizeY)
+	{
+		ATileField* TileField = World->SpawnActor<ATileField>(ATileField::StaticClass(), Location, FRotator::ZeroRotator);
+		TileField->SizeX = SizeX;
+		TileField->SizeY = SizeY;
+		TileField->OnConstruction(TileField->GetActorTransform());
+		return TileField;
+	}
+
+	AVNMapEvent* CreateMapEvent(UWorld* World, const FVector& Location)
+	{
+		return World->SpawnActor<AVNMapEvent>(AVNMapEvent::StaticClass(), Location, FRotator::ZeroRotator);
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMapSubsystemTileFieldRegistrationTest,
+	"GT5.Map.MapSubsystem.TileFields.RegisterAndQueryTiles",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMapSubsystemTileFieldRegistrationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = UWorld::CreateWorld(EWorldType::Editor, false);
+	TestNotNull(TEXT("Transient editor world should be created"), World);
+
+	UMapSubsystem* MapSubsystem = World->GetSubsystem<UMapSubsystem>();
+	TestNotNull(TEXT("Map subsystem should exist"), MapSubsystem);
+	MapSubsystem->Reset();
+
+	ATileField* TileField = CreateTileField(World, FVector::ZeroVector, 2, 3);
+	TestNotNull(TEXT("Tile field should spawn"), TileField);
+
+	MapSubsystem->AddTileField(nullptr);
+	MapSubsystem->AddTileField(TileField);
+	MapSubsystem->AddTileField(TileField);
+
+	TArray<FIntPoint> Tiles;
+	MapSubsystem->GetAllTiles(Tiles);
+	TestEqual(TEXT("Duplicate tile fields should be ignored"), Tiles.Num(), 6);
+	TestTrue(TEXT("Start tile should exist"), MapSubsystem->IsTileAt(FIntPoint(0, 0)));
+	TestTrue(TEXT("Last covered tile should exist"), MapSubsystem->IsTileAt(FIntPoint(1, 2)));
+	TestFalse(TEXT("X upper bound should be exclusive"), MapSubsystem->IsTileAt(FIntPoint(2, 0)));
+	TestFalse(TEXT("Y upper bound should be exclusive"), MapSubsystem->IsTileAt(FIntPoint(0, 3)));
+
+	MapSubsystem->RemoveTileField(TileField);
+	Tiles.Reset();
+	MapSubsystem->GetAllTiles(Tiles);
+	TestEqual(TEXT("Removed field should no longer contribute tiles"), Tiles.Num(), 0);
+
+	World->DestroyWorld(false);
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FMapSubsystemEventRegistrationTest,
+	"GT5.Map.MapSubsystem.MapEvents.IndexByTile",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FMapSubsystemEventRegistrationTest::RunTest(const FString& Parameters)
+{
+	UWorld* World = UWorld::CreateWorld(EWorldType::Editor, false);
+	TestNotNull(TEXT("Transient editor world should be created"), World);
+
+	UMapSubsystem* MapSubsystem = World->GetSubsystem<UMapSubsystem>();
+	TestNotNull(TEXT("Map subsystem should exist"), MapSubsystem);
+	MapSubsystem->Reset();
+
+	AVNMapEvent* FirstEvent = CreateMapEvent(World, FVector(50.0, 50.0, 0.0));
+	AVNMapEvent* SecondEvent = CreateMapEvent(World, FVector(50.0, 50.0, 0.0));
+	AVNMapEvent* InactiveEvent = CreateMapEvent(World, FVector(150.0, 50.0, 0.0));
+	TestNotNull(TEXT("First map event should spawn"), FirstEvent);
+	TestNotNull(TEXT("Second map event should spawn"), SecondEvent);
+	TestNotNull(TEXT("Inactive map event should spawn"), InactiveEvent);
+
+	MapSubsystem->AddMapEvent(nullptr);
+	MapSubsystem->AddMapEvent(FirstEvent);
+	MapSubsystem->AddMapEvent(FirstEvent);
+	TestEqual(TEXT("Duplicate events should be ignored"), MapSubsystem->GetAllMapEvents().Num(), 1);
+	TestEqual(TEXT("First event should be indexed by tile"), MapSubsystem->GetMapEventAt(FIntPoint(0, 0)), FirstEvent);
+
+	MapSubsystem->AddMapEvent(SecondEvent);
+	TestEqual(TEXT("Last added event wins by tile"), MapSubsystem->GetMapEventAt(FIntPoint(0, 0)), SecondEvent);
+
+	MapSubsystem->RemoveMapEvent(FirstEvent);
+	TestEqual(TEXT("Removing overwritten event should not clear current index"), MapSubsystem->GetMapEventAt(FIntPoint(0, 0)), SecondEvent);
+
+	MapSubsystem->AddMapEvent(InactiveEvent);
+	TestEqual(TEXT("Active event should be returned before deactivation"), MapSubsystem->GetMapEventAt(FIntPoint(1, 0)), InactiveEvent);
+	InactiveEvent->SetInactive();
+	TestNull(TEXT("Inactive events should be hidden from lookup"), MapSubsystem->GetMapEventAt(FIntPoint(1, 0)));
+
+	MapSubsystem->RemoveMapEvent(SecondEvent);
+	TestNull(TEXT("Removing indexed event should clear lookup"), MapSubsystem->GetMapEventAt(FIntPoint(0, 0)));
+
+	World->DestroyWorld(false);
+	return true;
+}
+
+#endif

--- a/Source/GT5_Projet/Private/Tests/SaveSubsystem.spec.cpp
+++ b/Source/GT5_Projet/Private/Tests/SaveSubsystem.spec.cpp
@@ -1,0 +1,75 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Subsystems/VNSaveSubsystem.h"
+
+#include "Misc/AutomationTest.h"
+#include "Save/VNSaveGame.h"
+
+namespace
+{
+	UVNSaveSubsystem* CreateSaveSubsystem()
+	{
+		return NewObject<UVNSaveSubsystem>();
+	}
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSaveSubsystemNullSaveGameTest,
+	"GT5.Save.VNSaveSubsystem.NullSaveGame.ReturnsDefaults",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSaveSubsystemNullSaveGameTest::RunTest(const FString& Parameters)
+{
+	UVNSaveSubsystem* SaveSubsystem = CreateSaveSubsystem();
+	TestNotNull(TEXT("Save subsystem should be created"), SaveSubsystem);
+
+	const FGuid Guid = FGuid::NewGuid();
+	FTableEvents Data;
+	Data.bTriggered = true;
+
+	TestNull(TEXT("Save game class should be null without a save game"), SaveSubsystem->GetSaveGameClass());
+
+	FTableEvents DefaultData = SaveSubsystem->GetEventData(Guid);
+	TestFalse(TEXT("Missing save game should return default event data"), DefaultData.bTriggered);
+
+	SaveSubsystem->SetEventData(Guid, Data);
+	DefaultData = SaveSubsystem->GetEventData(Guid);
+	TestFalse(TEXT("SetEventData should no-op without a save game"), DefaultData.bTriggered);
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FSaveSubsystemEventRoundTripTest,
+	"GT5.Save.VNSaveSubsystem.Events.RoundTripInMemory",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FSaveSubsystemEventRoundTripTest::RunTest(const FString& Parameters)
+{
+	UVNSaveSubsystem* SaveSubsystem = CreateSaveSubsystem();
+	TestNotNull(TEXT("Save subsystem should be created"), SaveSubsystem);
+
+	SaveSubsystem->SaveGame = NewObject<UVNSaveGame>(SaveSubsystem);
+	TestNotNull(TEXT("Transient save game should be created"), SaveSubsystem->SaveGame.Get());
+	TestTrue(TEXT("Save game class should reflect assigned save game"), SaveSubsystem->GetSaveGameClass() == UVNSaveGame::StaticClass());
+
+	const FGuid Guid = FGuid::NewGuid();
+	FTableEvents Data;
+	Data.bTriggered = true;
+	SaveSubsystem->SetEventData(Guid, Data);
+
+	const FTableEvents StoredData = SaveSubsystem->GetEventData(Guid);
+	TestTrue(TEXT("Stored event data should round-trip"), StoredData.bTriggered);
+
+	const FTableEvents MissingData = SaveSubsystem->GetEventData(FGuid::NewGuid());
+	TestFalse(TEXT("Unknown events should return default data"), MissingData.bTriggered);
+
+	Data.bTriggered = false;
+	SaveSubsystem->SetEventData(Guid, Data);
+	const FTableEvents ReplacedData = SaveSubsystem->GetEventData(Guid);
+	TestFalse(TEXT("SetEventData should replace existing event data"), ReplacedData.bTriggered);
+
+	return true;
+}
+
+#endif

--- a/Source/GT5_Projet/Private/Tests/TileMapLibrary.spec.cpp
+++ b/Source/GT5_Projet/Private/Tests/TileMapLibrary.spec.cpp
@@ -1,0 +1,52 @@
+#if WITH_DEV_AUTOMATION_TESTS
+
+#include "Libraries/VNTileMapLibrary.h"
+
+#include "Misc/AutomationTest.h"
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FTileMapLibraryWorldToTileTest,
+	"GT5.TileMap.VNTileMapLibrary.WorldToTile.UsesFloorBoundaries",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FTileMapLibraryWorldToTileTest::RunTest(const FString& Parameters)
+{
+	TestEqual(TEXT("Origin maps to tile 0,0"), UVNTileMapLibrary::GetTileCoordinatesFromWorldPos(FVector(0.0, 0.0, 0.0)), FIntPoint(0, 0));
+	TestEqual(TEXT("Positive values below tile size stay in tile 0"), UVNTileMapLibrary::GetTileCoordinatesFromWorldPos(FVector(99.9, 99.9, 0.0)), FIntPoint(0, 0));
+	TestEqual(TEXT("Positive tile boundary advances to next tile"), UVNTileMapLibrary::GetTileCoordinatesFromWorldPos(FVector(100.0, 100.0, 0.0)), FIntPoint(1, 1));
+	TestEqual(TEXT("Negative values floor toward the previous tile"), UVNTileMapLibrary::GetTileCoordinatesFromWorldPos(FVector(-0.1, -0.1, 0.0)), FIntPoint(-1, -1));
+	TestEqual(TEXT("Negative tile boundary stays exact"), UVNTileMapLibrary::GetTileCoordinatesFromWorldPos(FVector(-100.0, -100.0, 0.0)), FIntPoint(-1, -1));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FTileMapLibraryNearestTileTest,
+	"GT5.TileMap.VNTileMapLibrary.NearestTile.UsesHalfTileOffset",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FTileMapLibraryNearestTileTest::RunTest(const FString& Parameters)
+{
+	TestEqual(TEXT("Below half-tile snaps to current tile"), UVNTileMapLibrary::GetNearestTileFromWorldPos(FVector(49.9, 49.9, 0.0)), FIntPoint(0, 0));
+	TestEqual(TEXT("Half-tile boundary snaps forward"), UVNTileMapLibrary::GetNearestTileFromWorldPos(FVector(50.0, 50.0, 0.0)), FIntPoint(1, 1));
+	TestEqual(TEXT("Negative half-tile boundary is deterministic"), UVNTileMapLibrary::GetNearestTileFromWorldPos(FVector(-50.0, -50.0, 0.0)), FIntPoint(0, 0));
+	TestEqual(TEXT("Past negative half-tile snaps backward"), UVNTileMapLibrary::GetNearestTileFromWorldPos(FVector(-50.1, -50.1, 0.0)), FIntPoint(-1, -1));
+
+	return true;
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(
+	FTileMapLibraryTileToWorldTest,
+	"GT5.TileMap.VNTileMapLibrary.TileToWorld.ReturnsTileCenter",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
+
+bool FTileMapLibraryTileToWorldTest::RunTest(const FString& Parameters)
+{
+	TestEqual(TEXT("Tile 0,0 maps to center"), UVNTileMapLibrary::GetWorldPosFromTileCoordinates(FIntPoint(0, 0)), FVector(50.0, 50.0, 0.0));
+	TestEqual(TEXT("Positive tile maps to center"), UVNTileMapLibrary::GetWorldPosFromTileCoordinates(FIntPoint(2, 3)), FVector(250.0, 350.0, 0.0));
+	TestEqual(TEXT("Negative tile maps to center"), UVNTileMapLibrary::GetWorldPosFromTileCoordinates(FIntPoint(-1, -2)), FVector(-50.0, -150.0, 0.0));
+
+	return true;
+}
+
+#endif

--- a/Source/GT5_Projet/Public/Core/PawnIsometric.h
+++ b/Source/GT5_Projet/Public/Core/PawnIsometric.h
@@ -29,8 +29,6 @@ class GT5_PROJET_API APawnIsometric : public APawn
 {
 	GENERATED_BODY()
 
-	friend class AVNChapterManager;
-
 public:
 	// Sets default values for this pawn's properties
 	APawnIsometric();
@@ -86,6 +84,10 @@ public:
 
 	UFUNCTION(BlueprintCallable)
 	void SetCursorHidden(bool bCursorHidden);
+
+	void SetMapCharacter(AVNMapCharacter* InPlayerCharacter);
+	void SetMapBounds(AVNMapBounds* InMapBounds);
+	void SetCharacterHeightLevel(float InCharacterHeightLevel);
 
 
 	UPROPERTY(BlueprintReadOnly, EditAnywhere, Category="Camera")

--- a/Source/GT5_Projet/Public/Core/VNChapterManager.h
+++ b/Source/GT5_Projet/Public/Core/VNChapterManager.h
@@ -5,11 +5,14 @@
 #include "CoreMinimal.h"
 #include "Core/VNGamemode.h"
 
-#include "Map/VNMapCharacter.h"
-#include "Core/PawnIsometric.h"
 #include "Data/MinigameData.h"
 
 #include "VNChapterManager.generated.h"
+
+class APawnIsometric;
+class APlayerController;
+class AVNMapCharacter;
+class ULevelStreaming;
 
 /**
  * 
@@ -66,4 +69,10 @@ protected:
 
 	UPROPERTY(BlueprintReadOnly, Category="Chapter Runtime")
 	APawnIsometric* PawnCamera;
+
+private:
+	void SpawnChapterActors();
+	void PlaceCharacterAtPlayerStart();
+	void ConfigureCameraBounds(ULevelStreaming* LevelStream);
+	void ConfigureMapInput(APlayerController* PlayerController) const;
 };

--- a/Source/GT5_Projet/Public/Libraries/GridPathfinding.h
+++ b/Source/GT5_Projet/Public/Libraries/GridPathfinding.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * Pure grid pathfinding helpers. Unreal/world queries stay outside this class
+ * so the A* behavior can be characterized independently.
+ */
+class GT5_PROJET_API FGridPathfinding
+{
+public:
+	DECLARE_DELEGATE_RetVal_OneParam(bool, FIsWalkable, const FIntPoint&);
+	DECLARE_DELEGATE_RetVal_OneParam(bool, FIsTerminal, const FIntPoint&);
+
+	static bool FindPath(
+		const FIntPoint& StartTile,
+		const FIntPoint& EndTile,
+		TArray<FIntPoint>& OutPath,
+		const FIsWalkable& IsWalkable,
+		const FIsTerminal& IsTerminal,
+		int32 MaxSearchDistance = 1000);
+
+private:
+	struct FNode
+	{
+		FIntPoint Position;
+		float GCost = 0.0F;
+		float HCost = 0.0F;
+		int32 ParentIndex = INDEX_NONE;
+
+		float GetFCost() const { return GCost + HCost; }
+	};
+
+	static float CalculateManhattanDistance(const FIntPoint& A, const FIntPoint& B);
+	static void GetNeighbors(TArray<FIntPoint, TInlineAllocator<4>>& OutNeighbors, const FIntPoint& Position);
+};

--- a/Source/GT5_Projet/Public/Libraries/PathfindingLibrary.h
+++ b/Source/GT5_Projet/Public/Libraries/PathfindingLibrary.h
@@ -51,39 +51,10 @@ public:
 
 private:
 
-	// A* Node structure for pathfinding
-	struct FAStarNode
-	{
-		FIntPoint Position;
-		float GCost; // Distance from start
-		float HCost; // Heuristic distance to end
-		float FCost; // Total cost (G + H)
-		FAStarNode* Parent;
-
-		FAStarNode()
-			: Position(0, 0), GCost(0.f), HCost(0.f), FCost(0.f), Parent(nullptr)
-		{
-		}
-
-		FAStarNode(const FIntPoint& InPosition, float InGCost, float InHCost, FAStarNode* InParent = nullptr)
-			: Position(InPosition), GCost(InGCost), HCost(InHCost), FCost(InGCost + InHCost), Parent(InParent)
-		{
-		}
-
-		bool operator<(const FAStarNode& Other) const
-		{
-			return FCost < Other.FCost;
-		}
-	};
-
-	static float CalculateManhattanDistance(const FIntPoint& A, const FIntPoint& B);
-
 	static bool FindTileAt(FHitResult& OutResult, const FIntPoint& TilePosition, const UObject* WorldContext);
 
 	static bool IsTileFloor(AActor* HitActor);
 	static bool IsTileEvent(AActor* HitActor);
-
-	static void GetNeighbors(TInlineComponentArray<FIntPoint, 4>& out, const FIntPoint& Position);
 
 	static void DebugLogTile(const FHitResult& HitResult, const FIntPoint& TilePosition);
 };

--- a/Source/GT5_Projet/Public/Subsystems/VNChapterSubsystem.h
+++ b/Source/GT5_Projet/Public/Subsystems/VNChapterSubsystem.h
@@ -5,15 +5,16 @@
 #include "CoreMinimal.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 
-#include "Map/VNMapCharacter.h"
-#include "Core/PawnIsometric.h"
-#include "Core/VNChapterManager.h"
-#include "Minigames/BaseMinigameManager.h"
-
 #include "Data/ChapterData.h"
 #include "Data/MinigameData.h"
 
 #include "VNChapterSubsystem.generated.h"
+
+class ABaseMinigameManager;
+class APawn;
+class APawnIsometric;
+class AVNChapterManager;
+class AVNMapCharacter;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(
 	FOnConnectionChanged,
@@ -73,10 +74,10 @@ public:
 	AVNChapterManager* GetChapterManager() const { return ChapterManager; }
 
 	UFUNCTION(BlueprintCallable, BlueprintPure)
-	AVNMapCharacter* GetMapCharacter() const { return ChapterManager ? ChapterManager->GetMapCharacter() : 0; }
+	AVNMapCharacter* GetMapCharacter() const;
 
 	UFUNCTION(BlueprintCallable, BlueprintPure)
-	APawnIsometric* GetPawn() const { return ChapterManager ? ChapterManager->GetPawn() : 0; }
+	APawnIsometric* GetPawn() const;
 
 
 public:
@@ -124,4 +125,7 @@ private:
 
 	UFUNCTION()
 	void OnLevelLoadingDone();
+
+	bool SpawnMinigameRuntime(TSubclassOf<ABaseMinigameManager> ManagerClass, TSubclassOf<APawn> PawnClass);
+	void DestroyMinigameRuntime();
 };


### PR DESCRIPTION
## Summary
- Extract grid A* pathfinding into a pure helper and route the world-aware pathfinding library through it.
- Refactor chapter runtime setup/teardown and minigame spawning to reduce direct coupling and handle missing runtime actors.
- Add focused automation specs for pathfinding and subsystem/library behavior.

## Test plan
- Not run (Unreal build/test commands were not requested).

## Notes
- Includes an updated `Content/Game/Levels/Map_Persistent.umap` asset.